### PR TITLE
Optimize snapshot capabilities

### DIFF
--- a/vrtManager/instance.py
+++ b/vrtManager/instance.py
@@ -1210,10 +1210,20 @@ class wvmInstance(wvmConnect):
             name,
             time.time(),
         )
+        self.change_snapshot_xml()
         xml += self._XMLDesc(VIR_DOMAIN_XML_SECURE)
         xml += """<active>0</active>
                   </domainsnapshot>"""
         self._snapshotCreateXML(xml, 0)
+        self.recover_snapshot_xml()
+
+    def change_snapshot_xml(self):
+        xml_temp = self._XMLDesc(VIR_DOMAIN_XML_SECURE).replace("<loader readonly='yes' type='pflash'>","<loader readonly='yes' type='rom'>")
+        self._defineXML(xml_temp)
+
+    def recover_snapshot_xml(self):
+        xml_temp = self._XMLDesc(VIR_DOMAIN_XML_SECURE).replace("<loader readonly='yes' type='rom'>","<loader readonly='yes' type='pflash'>")
+        self._defineXML(xml_temp)
 
     def get_snapshot(self):
         snapshots = []
@@ -1229,8 +1239,10 @@ class wvmInstance(wvmConnect):
         snap.delete(0)
 
     def snapshot_revert(self, snapshot):
+        self.change_snapshot_xml()
         snap = self.instance.snapshotLookupByName(snapshot, 0)
         self.instance.revertToSnapshot(snap, 0)
+        self.recover_snapshot_xml()
 
     def get_managed_save_image(self):
         return self.instance.hasManagedSaveImage(0)


### PR DESCRIPTION
在arm平台创建虚拟机时，配置文件中"<loader>"标签下的type属性为"pflash"，此时无法打快照。
在打快照之前需将配置文件"<loader>"标签下的type属性手动指定为"rom"方可打快照，打快照结束后需将"rom"改回"pflash"以保证虚拟机正常运行。还原快照前也需将"pflash"手动改为"rom"，还原结束后将"rom"改回"pflash"。以上修改配置文件的权限是管理员权限，普通用户创建（还原）快照时无法自行修改配置文件，需联系管理员操作。为保证普通用户操作的流畅性，将修改配置文件的逻辑集成在相关函数中，打快照还原快照时系统自动修改配置文件。现在普通用户可以自行打快照还原快照了。
在webvirtcloud/vrtManager/instance.py文件中修改了函数create_snapshot(self, name)、snapshot_revert(self, snapshot)；增加了函数change_snapshot_xml(self)、recover_snapshot_xml(self)